### PR TITLE
Fix images that aren't displaying due to markdown formatting

### DIFF
--- a/doc/fr_FR/index.asciidoc
+++ b/doc/fr_FR/index.asciidoc
@@ -4,9 +4,13 @@ Ce plugin permet de gérer les cartes Ecodevice de GCE.
 Initialement, ce plugin a été créé pour connecter les Ecodevices de GCE.
 
 === Données visibles sur le Dashboard : ===
+
 * '''les compteurs de Téléinformation '''
+
 image::../images/ecodevice_screenshot2.jpg[]
+
 * '''les compteurs d'impulsions'''
+
 image::../images/ecodevice_screenshot3.jpg[]
 
 === Frequence de rafraichissement ===


### PR DESCRIPTION
If you look at https://jeedom.fr/doc/documentation/plugins/ecodevice/fr_FR/ecodevice.html, the images aren't being displayed, because the markdown format requires them to be on an isolated line (with blank line above and below).